### PR TITLE
Prevent Scoreboard Displaying

### DIFF
--- a/src/main/java/customhardcore/customhardcore/Helpers/ScoreboardHelper.java
+++ b/src/main/java/customhardcore/customhardcore/Helpers/ScoreboardHelper.java
@@ -16,6 +16,10 @@ import javax.annotation.Nullable;
 public class ScoreboardHelper {
 
     private static void createBoard(Player player) {
+
+        PlayerSettings playerSettings = PlayerSpecificSettings.getPlayerSettings(player);
+        if (!playerSettings.getSettings().get(Settings.TOGGLE_SCOREBOARD)) return;
+
         ScoreboardManager manager = Bukkit.getScoreboardManager();
         if (manager == null) return;
 


### PR DESCRIPTION
Prevents the Scoreboard from displaying when the User has toggled their display setting off.